### PR TITLE
Added External Application Whitelist support

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -86,6 +86,69 @@ module.exports = function (grunt) {
             },
             dest   : 'tmp/config_actual.xml'
          },
+         allOptionsExternalAppWhitelist: {
+              options: {
+                  id         : 'com.shustariov.mtclient',
+                  name       : 'MT Client',
+                  version    : '0.0.1',
+                  description: 'An application for money tracking',
+                  author     : {
+                      name : 'Andrey Shustariov',
+                      email: 'shutarev.andrey@gmail.com'
+                  },
+                  content    : {
+                      src: 'out/index.html'
+                  },
+                  access     : [
+                      {
+                          origin: '*'
+                      },
+                      {
+                          origin: 'tel:*',
+                          'launch-external': 'yes'
+                      },
+                      {
+                          origin: 'mailto:*',
+                          'launch-external': 'yes'
+                      }
+                  ],
+                  preferences: [
+                      {
+                          name : 'fullscreen',
+                          value: true
+                      },
+                      {
+                          name : 'webviewbounce',
+                          value: false
+                      },
+                      {
+                          name : 'UIWebViewBounce',
+                          value: false
+                      },
+                      {
+                          name : 'DisallowOverscroll',
+                          value: true
+                      },
+                      {
+                          name : 'BackupWebStorage',
+                          value: 'none'
+                      }
+                  ],
+                  features   : [
+                      {
+                          name  : 'StatusBar',
+                          params: [
+                              {
+                                  name  : 'ios-package',
+                                  value : 'CDVStatusBar',
+                                  onload: true
+                              }
+                          ]
+                      }
+                  ]
+              },
+              dest   : 'tmp/config_actual_external_app_whitelist.xml'
+         },
          defaultOptions : {
             dest : 'tmp/default-options.xml'
          }

--- a/tasks/cordova_config.js
+++ b/tasks/cordova_config.js
@@ -63,11 +63,17 @@ module.exports = function (grunt) {
                src : options.content.src
             }
          },
-         access : {
-            '@' : {
-               origin : options.access.origin
-            }
-         },
+         access : (options.access instanceof Array) !== true ? { '@': { origin: options.access.origin } } : options.access.map(function(opt) {
+             var _access = {
+                 '@': {
+                     origin: opt.origin
+                 }
+             };
+             if (!!opt['launch-external']) {
+                 _access['@']['launch-external'] = opt['launch-external'];
+             }
+             return _access;
+         }),
          preference : options.preferences.map(function(pref) {
             return {
                '@' : {

--- a/test/cordova_config_test.js
+++ b/test/cordova_config_test.js
@@ -36,6 +36,15 @@ exports.cordova_config = {
 
       test.done();
    },
+   all_options_external_app_whitelist: function (test) {
+        test.expect(1);
+
+        var actual = grunt.file.read('tmp/config_actual_external_app_whitelist.xml');
+        var expected = grunt.file.read('test/expected/config_external_app_whitelist_xml.xml');
+        test.equal(actual, expected, 'should generate valid config with external application whitelist.xml.');
+
+        test.done();
+   },
    default_options : function(test) {
       test.expect(1);
 

--- a/test/expected/config_external_app_whitelist_xml.xml
+++ b/test/expected/config_external_app_whitelist_xml.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<widget id="com.shustariov.mtclient" version="0.0.1" xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0">
+	<name>MT Client</name>
+	<description>An application for money tracking</description>
+	<author email="shutarev.andrey@gmail.com" href="">Andrey Shustariov</author>
+	<content src="out/index.html"/>
+	<access origin="*"/>
+	<access origin="tel:*" launch-external="yes"/>
+	<access origin="mailto:*" launch-external="yes"/>
+	<preference name="fullscreen" value="true"/>
+	<preference name="webviewbounce" value="false"/>
+	<preference name="UIWebViewBounce" value="false"/>
+	<preference name="DisallowOverscroll" value="true"/>
+	<preference name="BackupWebStorage" value="none"/>
+	<feature name="StatusBar">
+		<param name="ios-package" value="CDVStatusBar" onload="true"/>
+	</feature>
+</widget>


### PR DESCRIPTION
- Access tag support both Map and Array instances
- To use External Application Whitelist pass launch-external
  property along with appropriate origin in array of access
  property.
