### PR TITLE
Splash screens, easy icon, and platform-specific preferences

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -83,11 +83,17 @@ module.exports = function (grunt) {
                      ]
                   }
                ],
-               icon: {
-                  src: 'res/icon.png',
-                  width: 60,
-                  height: 60
-               },
+               icons: [
+                  {
+                     src: 'res/icon.png',
+                     width: 60,
+                     height: 60
+                  },
+                  {
+                     src: 'res/icon-rounded.png',
+                     platform: 'android'
+                  }
+               ],
                platforms  : [
                   {
                      name  : 'android',

--- a/README.md
+++ b/README.md
@@ -127,12 +127,21 @@ features : [
 
 Default value: `[]`
 
-#### options.icon
-Type: `Object` ([Image object](#image-objects))
+#### options.icons
+Type: `Array` of ([Image objects](#image-objects))
 
-References an image from which Cordova can generate appropriately-sized icons for each platform. Note that the `platform` option is not supported; use the `icons` option within `platforms` instead.
+References images from which Cordova can generate appropriately-sized icons for each platform. This is particularly useful for early prototypes for which platform-specific icons have not yet been created. See also the `icons` attribute in `options.platforms`.
 
-Default value: `null`
+_Example:_
+```js
+icons : [
+  {
+    src : 'res/icon-1024.png'
+  }
+]
+```
+
+Default value: `[]`
 
 #### options.platforms
 Type: `Array` of ([Platform objects](#platform-objects))
@@ -190,13 +199,18 @@ Please refer to the Cordova/PhoneGap Icons and Splash Screens documentation for 
 Type: `String`
 
 #### image.density
-Type: `String`
+Type: `String` (optional)
 
 #### image.width
-Type: `Number`
+Type: `Number` (optional)
 
 #### image.height
-Type: `Number`
+Type: `Number` (optional)
+
+#### image.platform
+Type: `String` (optional)
+
+For use in `option.icons`, though specifying icons in the `platforms` array may be preferable.
 
 ### Platform Objects
 
@@ -273,9 +287,11 @@ grunt.initConfig({
           ]
         }
       ],
-      icon : {
-        src : 'icon-default.png'
-      },
+      icons : [
+        {
+          src : 'icon-default.png'
+        }
+      ],
       platforms : [
         {
           name : 'ios',

--- a/tasks/cordova_config.js
+++ b/tasks/cordova_config.js
@@ -31,6 +31,9 @@ module.exports = function (grunt) {
       if ('height' in image) {
          i.height = image.height;
       }
+      if ('platform' in image) {
+         i.platform = image.platform;
+      }
       return { '@' : i };
    }
 
@@ -92,7 +95,7 @@ module.exports = function (grunt) {
          ],
          features : grunt.option('features') || [],
          platforms : grunt.option('platforms') || [],
-         icon : grunt.option('icon') || null
+         icons : grunt.option('icons') || []
       });
 
       var data = {
@@ -136,7 +139,7 @@ module.exports = function (grunt) {
                param : feature.params.map(attributesForParam)
             };
          }),
-         icon : attributesForImage(options.icon),
+         icon : options.icons.map(attributesForImage),
          platform : options.platforms.map(function(platform) {
             var icons = platform.icons || [];
             var splashScreens = platform.splash || [];

--- a/test/expected/config_xml.xml
+++ b/test/expected/config_xml.xml
@@ -14,6 +14,7 @@
 		<param name="ios-package" value="CDVStatusBar" onload="true"/>
 	</feature>
 	<icon src="res/icon.png" width="60" height="60"/>
+	<icon src="res/icon-rounded.png" platform="android"/>
 	<platform name="android">
 		<icon src="res/icon.jpg" density="ldpi"/>
 		<icon src="res/icon.jpg" width="50" height="50"/>


### PR DESCRIPTION
This adds support, tests, and documentation for 
- the top-level `icon` element from which Cordova derives platform-compatible icons
- the `splash` element within each platform
- the `preference` element within each platform

as documented [here](http://cordova.apache.org/docs/en/4.0.0/config_ref_images.md.html). There is also some cleanup and documentation for the `icon` element within each platform that was added by another contributor in an earlier pull request.

Sorry for the big PR, but due to the interdependencies between these changes (especially in the tests), multiple pull requests would have been more difficult to merge.
