### PR TITLE
Adds support for the config-file element used by cordova-custom-config.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -143,6 +143,34 @@ module.exports = function (grunt) {
                   name: "ios",
                   spec: '4'
                 }
+              ],
+              configFiles: [
+                {
+                  target: 'AndroidManifest.xml',
+                  parent: '/*',
+                  contents: {
+                    'supports-screens': {
+                      '@': {
+                        'android:xlargeScreens': false,
+                        'android:largeScreens': false,
+                        'android:smallScreens': true
+                      }
+                    },
+                    'uses-permission': [
+                      {
+                        '@': {
+                          'android:name': 'android.permission.READ_CONTACTS',
+                          'android:maxSdkVersion': 15
+                        }
+                      },
+                      {
+                        '@': {
+                          'android:name': 'android.permission.WRITE_CONTACTS'
+                        }
+                      }
+                    ]
+                  }
+                }
               ]
             },
             {
@@ -163,6 +191,31 @@ module.exports = function (grunt) {
                 {
                   name: 'fullscreen',
                   value: false
+                }
+              ],
+              configFiles: [
+                {
+                  target: '*-Info.plist',
+                  parent: 'UIBackgroundModes',
+                  contents: {
+                    array: {
+                      string: 'location'
+                    }
+                  }
+                },
+                {
+                  target: '*-Info.plist',
+                  parent: 'NSAppTransportSecurity',
+                  contents: {
+                    dict: {
+                      key: [
+                        'NSAllowsArbitraryLoads',
+                        {
+                          '=': 'true'
+                        }
+                      ]
+                    }
+                  }
                 }
               ]
             }

--- a/README.md
+++ b/README.md
@@ -683,6 +683,97 @@ The path to the hook to execute.
 }
 ```
 
+## options.configFiles
+
+A block of configuration file content for use with cordova-custom-config.
+
+**Type**: *Array&lt;object&gt; | object of:*
+
+### options.configFiles.target
+
+The config file to which the contents will be added.
+
+**Type**: *(required) string*
+
+### options.configFiles.parent
+
+The existing item under which the contents will be added (XPath for Android, plist key name for iOS).
+
+**Type**: *(required) string*
+
+### options.configFiles.contents
+
+The js2xmlparser-compatible JSON object to insert into the configuration file as XML.
+
+**Type**: *(required) object of:*
+
+[More Info](https://github.com/dpa99c/cordova-custom-config#config-files)
+
+**Default**: `[]`
+
+**Examples**
+
+```javascript
+// Add values to the AndroidManifest.xml file
+{
+    "target": "AndroidManifest.xml",
+    "parent": "/*",
+    "contents": {
+        "supports-screens": {
+            "@": {
+                "android:xlargeScreens": false,
+                "android:largeScreens": false,
+                "android:smallScreens": true
+            }
+        },
+        "uses-permission": [
+            {
+                "@": {
+                    "android:name": "android.permission.READ_CONTACTS",
+                    "android:maxSdkVersion": 15
+                }
+            },
+            {
+                "@": {
+                    "android:name": "android.permission.WRITE_CONTACTS"
+                }
+            }
+        ]
+    }
+}
+```
+
+```javascript
+// Add an array value to the iOS Info.plist file
+{
+    "target": "*-Info.plist",
+    "parent": "UIBackgroundModes",
+    "contents": {
+        "array": {
+            "string": "location"
+        }
+    }
+}
+```
+
+```javascript
+// Add a dict value to the iOS Info.plist file
+{
+    "target": "*-Info.plist",
+    "parent": "NSAppTransportSecurity",
+    "contents": {
+        "dict": {
+            "key": [
+                "NSAllowsArbitraryLoads",
+                {
+                    "=": "true"
+                }
+            ]
+        }
+    }
+}
+```
+
 ### Usage Examples
 
 #### Default Options

--- a/lib/configs.js
+++ b/lib/configs.js
@@ -3,7 +3,7 @@
 Object.defineProperty(exports, '__esModule', {
 	value: true
 });
-exports['default'] = ['root', 'author', 'content', 'access', 'allowIntent', 'allowNavigation', 'preference', 'feature', 'icon', 'splash', 'platform', 'engine', 'plugin', 'hook'].map(function (config) {
+exports['default'] = ['root', 'author', 'content', 'access', 'allowIntent', 'allowNavigation', 'preference', 'feature', 'icon', 'splash', 'platform', 'engine', 'plugin', 'hook', 'configFile'].map(function (config) {
 	return require('./configs/' + config);
 });
 module.exports = exports['default'];

--- a/lib/configs/configFile.js
+++ b/lib/configs/configFile.js
@@ -31,10 +31,53 @@ exports['default'] = {
 				}
 			},
 			examples: [{
-				title: 'Define the webview\'s background color.',
+				title: 'Add values to the AndroidManifest.xml file',
 				example: {
-					name: 'BackgroundColor',
-					value: '0xff0000ff'
+					target: 'AndroidManifest.xml',
+					parent: '/*',
+					contents: {
+						'supports-screens': {
+							'@': {
+								'android:xlargeScreens': false,
+								'android:largeScreens': false,
+								'android:smallScreens': true
+							}
+						},
+						'uses-permission': [{
+							'@': {
+								'android:name': 'android.permission.READ_CONTACTS',
+								'android:maxSdkVersion': 15
+							}
+						}, {
+							'@': {
+								'android:name': 'android.permission.WRITE_CONTACTS'
+							}
+						}]
+					}
+				}
+			}, {
+				title: 'Add an array value to the iOS Info.plist file',
+				example: {
+					target: '*-Info.plist',
+					parent: 'UIBackgroundModes',
+					contents: {
+						array: {
+							string: 'location'
+						}
+					}
+				}
+			}, {
+				title: 'Add a dict value to the iOS Info.plist file',
+				example: {
+					target: '*-Info.plist',
+					parent: 'NSAppTransportSecurity',
+					contents: {
+						dict: {
+							key: ['NSAllowsArbitraryLoads', {
+								'=': 'true'
+							}]
+						}
+					}
 				}
 			}],
 			moreInfo: 'https://github.com/dpa99c/cordova-custom-config#config-files'

--- a/lib/configs/configFile.js
+++ b/lib/configs/configFile.js
@@ -1,0 +1,60 @@
+'use strict';
+
+Object.defineProperty(exports, '__esModule', {
+	value: true
+});
+exports['default'] = {
+	occurances: 'multiple',
+	hasMany: true,
+	optionsKey: 'configFiles',
+	getDefaultOptions: function getDefaultOptions() {
+		return [];
+	},
+	getDocumentation: function getDocumentation() {
+		return {
+			description: 'A block of configuration file content for use with cordova-custom-config.',
+			type: {
+				target: {
+					description: 'The config file to which the contents will be added.',
+					type: 'string',
+					required: true
+				},
+				parent: {
+					description: 'The existing item under which the contents will be added (XPath for Android, plist key name for iOS).',
+					type: 'string',
+					required: true
+				},
+				contents: {
+					description: 'The js2xmlparser-compatible JSON object to insert into the configuration file as XML.',
+					type: 'object',
+					required: true
+				}
+			},
+			examples: [{
+				title: 'Define the webview\'s background color.',
+				example: {
+					name: 'BackgroundColor',
+					value: '0xff0000ff'
+				}
+			}],
+			moreInfo: 'https://github.com/dpa99c/cordova-custom-config#config-files'
+		};
+	},
+	processor: function processor(configFiles, _processor) {
+		return {
+			'config-file': configFiles.map(function (configFile) {
+				var target = configFile.target;
+				var parent = configFile.parent;
+				var contents = configFile.contents;
+
+				contents['@'] = {
+					target: target,
+					parent: parent
+				};
+
+				return contents;
+			})
+		};
+	}
+};
+module.exports = exports['default'];

--- a/lib/configs/configFile.js
+++ b/lib/configs/configFile.js
@@ -3,6 +3,9 @@
 Object.defineProperty(exports, '__esModule', {
 	value: true
 });
+
+var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
+
 exports['default'] = {
 	occurances: 'multiple',
 	hasMany: true,
@@ -90,12 +93,12 @@ exports['default'] = {
 				var parent = configFile.parent;
 				var contents = configFile.contents;
 
-				contents['@'] = {
-					target: target,
-					parent: parent
-				};
-
-				return contents;
+				return _extends({
+					'@': {
+						target: target,
+						parent: parent
+					}
+				}, contents);
 			})
 		};
 	}

--- a/src/configs.js
+++ b/src/configs.js
@@ -12,5 +12,6 @@ export default [
 	'platform',
 	'engine',
 	'plugin',
-	'hook'
+	'hook',
+	'configFile'
 ].map((config) => require('./configs/'+config));

--- a/src/configs/configFile.js
+++ b/src/configs/configFile.js
@@ -1,0 +1,48 @@
+export default {
+	occurances: 'multiple',
+	hasMany: true,
+	optionsKey: 'configFiles',
+	getDefaultOptions(){
+		return [];
+	},
+	getDocumentation(){
+		return {
+			description: 'A block of configuration file content for use with cordova-custom-config.',
+			type: {
+				target: {
+					description: 'The config file to which the contents will be added.',
+					type: 'string',
+					required: true
+				},
+				parent: {
+					description: 'The existing item under which the contents will be added (XPath for Android, plist key name for iOS).',
+					type: 'string',
+					required: true
+				},
+				contents: {
+					description: 'The js2xmlparser-compatible JSON object to insert into the configuration file as XML.',
+					type: 'object',
+					required: true
+				}
+			},
+			examples: [
+				// TODO
+			],
+			moreInfo: 'https://github.com/dpa99c/cordova-custom-config#config-files'
+		};
+	},
+	processor(configFiles,processor){
+		return {
+			'config-file': configFiles.map((configFile) => {
+				let {target,parent,contents} = configFile;
+
+				contents['@'] = {
+					target,
+					parent
+				};
+				
+				return contents;
+			})
+		};
+	}
+};

--- a/src/configs/configFile.js
+++ b/src/configs/configFile.js
@@ -26,7 +26,64 @@ export default {
 				}
 			},
 			examples: [
-				// TODO
+				{
+					title: 'Add values to the AndroidManifest.xml file',
+					example: {
+						target: 'AndroidManifest.xml',
+						parent: '/*',
+						contents: {
+							'supports-screens': {
+								'@': {
+									'android:xlargeScreens': false,
+									'android:largeScreens': false,
+									'android:smallScreens': true
+								}
+							},
+							'uses-permission': [
+								{
+									'@': {
+										'android:name': 'android.permission.READ_CONTACTS',
+										'android:maxSdkVersion': 15
+									}
+								},
+								{
+									'@': {
+										'android:name': 'android.permission.WRITE_CONTACTS'
+									}
+								}
+							]
+						}
+					}
+				},
+				{
+					title: 'Add an array value to the iOS Info.plist file',
+					example: {
+						target: '*-Info.plist',
+						parent: 'UIBackgroundModes',
+						contents: {
+							array: {
+								string: 'location'
+							}
+						}
+					}
+				},
+				{
+					title: 'Add a dict value to the iOS Info.plist file',
+					example: {
+						target: '*-Info.plist',
+						parent: 'NSAppTransportSecurity',
+						contents: {
+							dict: {
+								key: [
+									'NSAllowsArbitraryLoads',
+									{
+										'=': 'true'
+									}
+								]
+							}
+						}
+					}
+				}
 			],
 			moreInfo: 'https://github.com/dpa99c/cordova-custom-config#config-files'
 		};

--- a/src/configs/configFile.js
+++ b/src/configs/configFile.js
@@ -93,12 +93,15 @@ export default {
 			'config-file': configFiles.map((configFile) => {
 				let {target,parent,contents} = configFile;
 
-				contents['@'] = {
-					target,
-					parent
+				return {
+					'@': {
+						target,
+						parent
+					},
+					/* jshint ignore:start */
+					...contents
+					/* jshint ignore:end */
 				};
-				
-				return contents;
 			})
 		};
 	}

--- a/test/expected/config_xml.xml
+++ b/test/expected/config_xml.xml
@@ -24,11 +24,28 @@
 		<icon src="res/icon.jpg" width="50" height="50"/>
 		<splash src="res/splash-hdpi.png" density="port-hdpi"/>
 		<splash src="res/splash-mdpi.png" density="port-mdpi"/>
+		<config-file target="AndroidManifest.xml" parent="/*">
+			<supports-screens android:xlargeScreens="false" android:largeScreens="false" android:smallScreens="true"/>
+			<uses-permission android:name="android.permission.READ_CONTACTS" android:maxSdkVersion="15"/>
+			<uses-permission android:name="android.permission.WRITE_CONTACTS"/>
+		</config-file>
 	</platform>
 	<platform name="ios">
 		<preference name="fullscreen" value="false"/>
 		<icon src="res/icon.jpg"/>
 		<splash src="res/splash.png" width="320" height="480"/>
+		<config-file target="*-Info.plist" parent="UIBackgroundModes">
+			<array>
+				<string>location</string>
+			</array>
+		</config-file>
+		<config-file target="*-Info.plist" parent="NSAppTransportSecurity">
+			<dict>
+				<key>NSAllowsArbitraryLoads</key>
+				<true>
+				</true>
+			</dict>
+		</config-file>
 	</platform>
 	<engine name="android" spec="4.0.2"/>
 	<plugin name="cordova-plugin-file" spec="^3.0.0"/>


### PR DESCRIPTION
[cordova-custom-config](https://github.com/dpa99c/cordova-custom-config) allows modification of the *-Info.plist and AndroidManifest.xml configuration files to cover cases where a cordova plugin may not exist for the settings you need. Since both of these files are XML-formatted, the module simply takes the content of the <config-file> element and inserts into the appropriate file as directed.

Unfortunately, js2xmlparser does not allow blocks of XML as strings, so in order to support this in grunt-cordova-config it is necessary to write the config in js2xmlparser-compatible JSON. This is a challenge, but can be done, at least [well enough](https://github.com/michaelkourlas/node-js2xmlparser/issues/34).

Lacks README documentation and examples since I am unsure whether this functionality will be acceptable and useful for others. I will gladly finish that up if this addition is useful for others.

**NOTE** the tests will fail for an unrelated reason: the current test process assumes that the config keys will be iterated in the order specified. After adding the additional config, the objects specified in the Gruntfile no longer preserve key order. I am not sure how to approach that issue.
